### PR TITLE
Use "x" letter(from main keyboard) for multiplication

### DIFF
--- a/app/src/modules/calculator/calculator.js
+++ b/app/src/modules/calculator/calculator.js
@@ -27,6 +27,7 @@ module.exports = {
             } else {
                 values[0] = values[0].toLowerCase();
                 values[0] = values[0].replace("×","*");
+                values[0] = values[0].replace("x","*");
                 values[0] = values[0].replace("÷","/");
                 values[0] = values[0].replace("¹", "^1");
                 values[0] = values[0].replace("²", "^2");
@@ -66,7 +67,7 @@ module.exports = {
      * The keyword can be a regex. If you need help for your regex, use this https://regex101.com/#javascript
      */
 
-    keyword: "(\\+|\\-|\\*|\\/|×|÷|¹|²|³|[0-9]|\\(|\\)|\\.|\\s|E|PI|PHI|cos|sin|sqrt|log|tan|exp|\\^)*",
+    keyword: "(\\+|\\-|\\*|\\/|×|x|÷|¹|²|³|[0-9]|\\(|\\)|\\.|\\s|E|PI|PHI|cos|sin|sqrt|log|tan|exp|\\^)*",
 
     /**
      * (NEEDED)


### PR DESCRIPTION
Try on macOS, Google Chrome:

See https://www.qwant.com/?q=12x12&t=web => no IA but https://www.google.com/search?q=12x12 => IA !

"x" letter seems not taken in consideration (maybe this is the normal behavior, I never know with Qwant ^^)

(<!> didnt test the code, I did the PR via github web IDE <!>)

thanks.